### PR TITLE
Feature/replace webserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ ClientBin/
 *.pfx
 *.publishsettings
 orleans.codegen.cs
+HlaeObsTools/Properties/PublishProfiles

--- a/HlaeObsTools.sln
+++ b/HlaeObsTools.sln
@@ -1,9 +1,12 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31903.59
+# Visual Studio Version 18
+VisualStudioVersion = 18.3.11512.155 d18.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HlaeObsTools", "HlaeObsTools\HlaeObsTools.csproj", "{8B3E1F0A-5C6D-4F7E-9A2B-1D3E4F5A6B7C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Renderer", "external\ValveResourceFormat\Renderer\Renderer.csproj", "{BBB3AEBD-D620-8CB6-C5F9-A531EA50CCC0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ValveResourceFormat", "external\ValveResourceFormat\ValveResourceFormat\ValveResourceFormat.csproj", "{FCD5F29E-849B-6694-8815-EC37D15752D0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,5 +18,16 @@ Global
 		{8B3E1F0A-5C6D-4F7E-9A2B-1D3E4F5A6B7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8B3E1F0A-5C6D-4F7E-9A2B-1D3E4F5A6B7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8B3E1F0A-5C6D-4F7E-9A2B-1D3E4F5A6B7C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BBB3AEBD-D620-8CB6-C5F9-A531EA50CCC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BBB3AEBD-D620-8CB6-C5F9-A531EA50CCC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BBB3AEBD-D620-8CB6-C5F9-A531EA50CCC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BBB3AEBD-D620-8CB6-C5F9-A531EA50CCC0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FCD5F29E-849B-6694-8815-EC37D15752D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FCD5F29E-849B-6694-8815-EC37D15752D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FCD5F29E-849B-6694-8815-EC37D15752D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FCD5F29E-849B-6694-8815-EC37D15752D0}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/HlaeObsTools/HlaeObsTools.csproj
+++ b/HlaeObsTools/HlaeObsTools.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="Vortice.DXGI" Version="3.6.2" />
     <PackageReference Include="Vortice.Direct2D1" Version="3.6.2" />
     <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.9.4" />
+    <PackageReference Include="Watson" Version="6.5.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HlaeObsTools/Services/Settings/SettingsStorage.cs
+++ b/HlaeObsTools/Services/Settings/SettingsStorage.cs
@@ -71,6 +71,7 @@ public class AppSettingsData
     public int WebSocketPort { get; set; } = 31338;
     public int UdpPort { get; set; } = 31339;
     public int RtpPort { get; set; } = 5000;
+    public string GsiBindAddress { get; set; } = "0.0.0.0";
     public int GsiPort { get; set; } = 31337;
     public string MapObjPath { get; set; } = string.Empty;
     public bool ViewportUseLegacyD3D11 { get; set; }

--- a/HlaeObsTools/ViewModels/Docks/RadarDockViewModel.cs
+++ b/HlaeObsTools/ViewModels/Docks/RadarDockViewModel.cs
@@ -537,7 +537,6 @@ public sealed class RadarDockViewModel : Tool, IDisposable
         CanPin = true;
 
         _gsiServer.GameStateUpdated += OnGameStateUpdated;
-        _gsiServer.Start(); // fire and forget
 
         _settings.PropertyChanged += OnSettingsChanged;
 

--- a/HlaeObsTools/ViewModels/Docks/SettingsDockViewModel.cs
+++ b/HlaeObsTools/ViewModels/Docks/SettingsDockViewModel.cs
@@ -39,7 +39,7 @@ namespace HlaeObsTools.ViewModels.Docks
         private bool _suppressSettingsSave;
         private bool _isLoadingPresets;
 
-        public record NetworkSettingsData(string WebSocketHost, int WebSocketPort, int UdpPort, int RtpPort, int GsiPort);
+        public record NetworkSettingsData(string WebSocketHost, int WebSocketPort, int UdpPort, int RtpPort, string GsiBindAddress, int GsiPort);
 
         public SettingsDockViewModel(RadarSettings radarSettings, HudSettings hudSettings, FreecamSettings freecamSettings, Viewport3DSettings viewport3DSettings, SettingsStorage settingsStorage, HlaeWebSocketClient wsClient, Func<NetworkSettingsData, Task>? applyNetworkSettingsAsync = null, AppSettingsData? storedSettings = null, VmixReplaySettings? vmixSettings = null, Action<bool>? setFocusInputGateDisabled = null, CampathEditorViewModel? campathEditor = null)
         {
@@ -65,6 +65,7 @@ namespace HlaeObsTools.ViewModels.Docks
             _webSocketPort = settings.WebSocketPort;
             _udpPort = settings.UdpPort;
             _rtpPort = settings.RtpPort;
+            _gsiBindAddress = settings.GsiBindAddress;
             _gsiPort = settings.GsiPort;
             _disableFocusInputGate = settings.DisableFocusInputGate;
 
@@ -175,6 +176,20 @@ namespace HlaeObsTools.ViewModels.Docks
             }
         }
 
+        private string _gsiBindAddress = "127.0.0.1";
+        public string GsiBindAddress
+        {
+            get => _gsiBindAddress;
+            set
+            {
+                if (_gsiBindAddress != value)
+                {
+                    _gsiBindAddress = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
         private int _gsiPort = 31337;
         public int GsiPort
         {
@@ -196,7 +211,7 @@ namespace HlaeObsTools.ViewModels.Docks
             SaveSettings();
             if (_applyNetworkSettingsAsync != null)
             {
-                var payload = new NetworkSettingsData(WebSocketHost, WebSocketPort, UdpPort, RtpPort, GsiPort);
+                var payload = new NetworkSettingsData(WebSocketHost, WebSocketPort, UdpPort, RtpPort, GsiBindAddress, GsiPort);
                 await _applyNetworkSettingsAsync(payload);
             }
         }
@@ -506,6 +521,7 @@ namespace HlaeObsTools.ViewModels.Docks
                 WebSocketPort = WebSocketPort,
                 UdpPort = UdpPort,
                 RtpPort = RtpPort,
+                GsiBindAddress = GsiBindAddress,
                 GsiPort = GsiPort,
                 MapObjPath = _viewport3DSettings.MapObjPath,
                 ViewportUseLegacyD3D11 = _viewport3DSettings.UseLegacyD3D11Viewport,

--- a/HlaeObsTools/ViewModels/MainDockFactory.cs
+++ b/HlaeObsTools/ViewModels/MainDockFactory.cs
@@ -93,6 +93,7 @@ public class MainDockFactory : Factory, IDisposable
         _storedSettings.WebSocketPort = data.WebSocketPort;
         _storedSettings.UdpPort = data.UdpPort;
         _storedSettings.RtpPort = data.RtpPort;
+        _storedSettings.GsiBindAddress = data.GsiBindAddress;
         _storedSettings.GsiPort = data.GsiPort;
         _settingsStorage.Save(_storedSettings);
 
@@ -105,7 +106,7 @@ public class MainDockFactory : Factory, IDisposable
         {
             _videoDisplayVm.SetRtpConfig(new Services.Video.RTP.RtpReceiverConfig
             {
-                Address = "0.0.0.0",
+                Address = data.GsiBindAddress,
                 Port = data.RtpPort
             });
 
@@ -118,7 +119,7 @@ public class MainDockFactory : Factory, IDisposable
 
         // Restart GSI listener with new endpoint
         _gsiServer.Stop();
-        _gsiServer.Start(data.GsiPort, "/gsi/", "0.0.0.0");
+        _gsiServer.Start(data.GsiPort, "/gsi/", data.GsiBindAddress);
     }
 
     public override IDocumentDock CreateDocumentDock() => new DocumentDock();
@@ -212,11 +213,11 @@ public class MainDockFactory : Factory, IDisposable
         ConfigureAnalogInput(freecamSettings);
         _videoDisplayVm.SetRtpConfig(new Services.Video.RTP.RtpReceiverConfig
         {
-            Address = "0.0.0.0",
+            Address = _storedSettings.GsiBindAddress,
             Port = _storedSettings.RtpPort
         });
         // Start GSI listener on all interfaces with configured port
-        _gsiServer.Start(_storedSettings.GsiPort, "/gsi/", "0.0.0.0");
+        _gsiServer.Start(_storedSettings.GsiPort, "/gsi/", _storedSettings.GsiBindAddress);
         bottomRight.SetWebSocketClient(_webSocketClient);
 
         // Wrap tools in ToolDocks for proper docking behavior

--- a/HlaeObsTools/Views/Docks/SettingsDockView.axaml
+++ b/HlaeObsTools/Views/Docks/SettingsDockView.axaml
@@ -64,15 +64,17 @@
                             ColumnSpacing="8"
                             RowSpacing="6">
                             <TextBlock Grid.Row="0" Grid.Column="0" Text="WS/UDP Host" Foreground="#AAAAAA"/>
-                            <TextBox Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="3" Text="{Binding WebSocketHost, Mode=TwoWay}" />
+                            <TextBox Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="1" Text="{Binding WebSocketHost, Mode=TwoWay}" />
+							<TextBlock Grid.Row="0" Grid.Column="2" Text="RTP Port" Foreground="#AAAAAA"/>
+							<TextBox Grid.Row="0" Grid.Column="3" Text="{Binding RtpPort, Mode=TwoWay}" />
 
                             <TextBlock Grid.Row="1" Grid.Column="0" Text="WS Port" Foreground="#AAAAAA"/>
                             <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding WebSocketPort, Mode=TwoWay}" />
                             <TextBlock Grid.Row="1" Grid.Column="2" Text="UDP Port" Foreground="#AAAAAA"/>
                             <TextBox Grid.Row="1" Grid.Column="3" Grid.ColumnSpan="3" Text="{Binding UdpPort, Mode=TwoWay}" />
 
-                            <TextBlock Grid.Row="2" Grid.Column="0" Text="RTP Port" Foreground="#AAAAAA"/>
-                            <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding RtpPort, Mode=TwoWay}" />
+							<TextBlock Grid.Row="2" Grid.Column="0" Text="GSI Bind Address" Foreground="#AAAAAA"/>
+							<TextBox Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="1" Text="{Binding GsiBindAddress, Mode=TwoWay}" />
                             <TextBlock Grid.Row="2" Grid.Column="2" Text="GSI Port" Foreground="#AAAAAA"/>
                             <TextBox Grid.Row="2" Grid.Column="3" Grid.ColumnSpan="3" Text="{Binding GsiPort, Mode=TwoWay}" />
                         </Grid>


### PR DESCRIPTION
## Replace HttpListener to Watson Webserver & add bind address for GSI server
Had to replace the vanilla .NET HttpListener with Watson Webserver; HttpListener doesn't work on Linux with Wine.
Had to add a configurable bind address for the GSI server as the default 0.0.0.0 doesn't seem to work.
Tested locally on openSUSE Linux with both normal Wine and Steam's Proton.