### PR TITLE
Clickable radar players

### DIFF
--- a/HlaeObsTools/Controls/D3D11Viewport.cs
+++ b/HlaeObsTools/Controls/D3D11Viewport.cs
@@ -531,9 +531,14 @@ public sealed class D3D11Viewport : NativeControlHost, IViewport3DControl
     public void TeleportCamera(Vector3 position, Quaternion rotation, float fov)
     {
         _freecamTransform.Position = position;
+        _freecamSmoothed.Position = position;
         _freecamTransform.Orientation = rotation;
+        _freecamSmoothed.Orientation = rotation;
         _freecamTransform.Fov = fov;
+        _freecamSmoothed.Fov = fov;
         _externalCameraActive = false;
+        _freecamActive = true;
+        RequestNextFrame();
     }
     public void SetExternalCamera(Vector3 position, Quaternion rotation, float fov)
     {

--- a/HlaeObsTools/Controls/D3D11Viewport.cs
+++ b/HlaeObsTools/Controls/D3D11Viewport.cs
@@ -528,6 +528,13 @@ public sealed class D3D11Viewport : NativeControlHost, IViewport3DControl
         EndFreecamInput();
     }
 
+    public void TeleportCamera(Vector3 position, Quaternion rotation, float fov)
+    {
+        _freecamTransform.Position = position;
+        _freecamTransform.Orientation = rotation;
+        _freecamTransform.Fov = fov;
+        _externalCameraActive = false;
+    }
     public void SetExternalCamera(Vector3 position, Quaternion rotation, float fov)
     {
         _externalCameraPosition = position;

--- a/HlaeObsTools/Controls/IViewport3DControl.cs
+++ b/HlaeObsTools/Controls/IViewport3DControl.cs
@@ -22,6 +22,7 @@ public interface IViewport3DControl
 
     bool TryGetFreecamState(out ViewportFreecamState state);
     void DisableFreecamInput();
+    void TeleportCamera(Vector3 position, Quaternion rotation, float fov);
     void SetExternalCamera(Vector3 position, Quaternion rotation, float fov);
     void ClearExternalCamera();
     void SetFreecamPose(Vector3 position, Quaternion rotation, float fov);

--- a/HlaeObsTools/Controls/VRFViewport.cs
+++ b/HlaeObsTools/Controls/VRFViewport.cs
@@ -942,6 +942,14 @@ public sealed class VRFViewport : NativeControlHost, IViewport3DControl
         EndFreecamInput();
     }
 
+    public void TeleportCamera(Vector3 position, Quaternion rotation, float fov)
+    {
+        _freecamTransform.Position = position;
+        _freecamTransform.Orientation = rotation;
+        _freecamTransform.Fov = fov;
+        _externalCameraActive = false;
+    }
+
     public void SetExternalCamera(Vector3 position, Quaternion rotation, float fov)
     {
         _externalCameraPosition = position;

--- a/HlaeObsTools/Controls/VRFViewport.cs
+++ b/HlaeObsTools/Controls/VRFViewport.cs
@@ -945,9 +945,14 @@ public sealed class VRFViewport : NativeControlHost, IViewport3DControl
     public void TeleportCamera(Vector3 position, Quaternion rotation, float fov)
     {
         _freecamTransform.Position = position;
+        _freecamSmoothed.Position = position;
         _freecamTransform.Orientation = rotation;
+        _freecamSmoothed.Orientation = rotation;
         _freecamTransform.Fov = fov;
+        _freecamSmoothed.Fov = fov;
         _externalCameraActive = false;
+        _freecamActive = true;
+        RequestNextFrame();
     }
 
     public void SetExternalCamera(Vector3 position, Quaternion rotation, float fov)

--- a/HlaeObsTools/ViewModels/Docks/RadarDockViewModel.cs
+++ b/HlaeObsTools/ViewModels/Docks/RadarDockViewModel.cs
@@ -1004,8 +1004,11 @@ public sealed class RadarDockViewModel : Tool, IDisposable
             new System.Numerics.Vector3(
                 (float)player.IngamePosition.X,
                 (float)player.IngamePosition.Y,
-                (float)player.IngamePosition.Z),
-            Quaternion.Identity,
+                (float)player.IngamePosition.Z + 64), // eye height. probably.
+            Quaternion.CreateFromYawPitchRoll(
+                (float)(player.Rotation / 180.0 * double.Pi),
+                0,
+                0),
             (float)_viewportVm.FreecamSettings.DefaultFov
             );
     }

--- a/HlaeObsTools/ViewModels/Docks/RadarDockViewModel.cs
+++ b/HlaeObsTools/ViewModels/Docks/RadarDockViewModel.cs
@@ -15,6 +15,9 @@ using Dock.Model.Mvvm.Controls;
 using HlaeObsTools.Services.Gsi;
 using HlaeObsTools.Services.Campaths;
 using HlaeObsTools.Services.WebSocket;
+using HlaeObsTools.Views.Docks;
+using HlaeObsTools.Controls;
+using System.Numerics;
 
 namespace HlaeObsTools.ViewModels.Docks;
 
@@ -23,6 +26,7 @@ public sealed class RadarPlayerViewModel : ViewModelBase
     private const double MarkerWidth = 36.0;
     private double _relativeX;
     private double _relativeY;
+    private Vec3 _ingamePos;
     private double _rotation;
     private bool _isAlive;
     private bool _hasBomb;
@@ -128,6 +132,12 @@ public sealed class RadarPlayerViewModel : ViewModelBase
     {
         get => _relativeY;
         set => SetProperty(ref _relativeY, value);
+    }
+
+    public Vec3 IngamePosition
+    {
+        get => _ingamePos;
+        set => SetProperty(ref _ingamePos, value);
     }
 
     public double Rotation
@@ -482,6 +492,7 @@ public sealed class RadarDockViewModel : Tool, IDisposable
     private readonly Dictionary<string, RadarDeadPlayerViewModel> _deadPlayerMarkers = new();
     private readonly Dictionary<string, Vec3> _lastAlivePositions = new();
     private readonly Dictionary<string, int> _playerHeightBuckets = new();
+    private readonly Viewport3DDockViewModel _viewportVm;
     private readonly CampathsDockViewModel? _campathsVm;
     private readonly HlaeWebSocketClient? _webSocketClient;
     private readonly RadarSettings _settings;
@@ -522,7 +533,7 @@ public sealed class RadarDockViewModel : Tool, IDisposable
 
     public RadarSettings RadarSettings => _settings;
 
-    public RadarDockViewModel(GsiServer gsiServer, RadarConfigProvider configProvider, RadarSettings settings, CampathsDockViewModel? campathsVm, HlaeWebSocketClient? webSocketClient)
+    public RadarDockViewModel(GsiServer gsiServer, RadarConfigProvider configProvider, RadarSettings settings, CampathsDockViewModel? campathsVm, HlaeWebSocketClient? webSocketClient, Viewport3DDockViewModel viewportVM)
     {
         _gsiServer = gsiServer;
         _configProvider = configProvider;
@@ -530,6 +541,7 @@ public sealed class RadarDockViewModel : Tool, IDisposable
         _campathsVm = campathsVm;
         _webSocketClient = webSocketClient;
         _projector = new RadarProjector(configProvider);
+        _viewportVm = viewportVM;
 
         Title = "Radar";
         CanClose = false;
@@ -668,6 +680,7 @@ public sealed class RadarDockViewModel : Tool, IDisposable
                 vm.Slot = p.Slot;
                 vm.RelativeX = x;
                 vm.RelativeY = y;
+                vm.IngamePosition = new Vec3(p.Position.X, p.Position.Y, p.Position.Z);
                 vm.CanvasX = x * 1024.0 - 18.0; // center the 36px marker on the projected point
                 vm.CanvasY = y * 1024.0 - 22.0;
                 vm.Rotation = NormalizeDegrees(Math.Atan2(p.Forward.X, p.Forward.Y) * 180.0 / Math.PI);
@@ -969,6 +982,32 @@ public sealed class RadarDockViewModel : Tool, IDisposable
         {
             RefreshCampathOverlay();
         }
+    }
+
+    public void SwitchToPlayer(RadarPlayerViewModel player)
+    {
+        if (_webSocketClient == null)
+            return;
+
+        _webSocketClient.SendExecCommandAsync($"spec_player {player.Name}");
+    }
+
+    public void TeleportViewportCameraToPlayer(RadarPlayerViewModel player)
+    {
+        if (_viewportVm == null)
+            return;
+
+        if (_viewportVm.Viewport == null)
+            return;
+
+        _viewportVm.Viewport.TeleportCamera(
+            new System.Numerics.Vector3(
+                (float)player.IngamePosition.X,
+                (float)player.IngamePosition.Y,
+                (float)player.IngamePosition.Z),
+            Quaternion.Identity,
+            (float)_viewportVm.FreecamSettings.DefaultFov
+            );
     }
 
     private void OnFlashCleanupTick(object? sender, EventArgs e)

--- a/HlaeObsTools/ViewModels/Docks/Viewport3DDockViewModel.cs
+++ b/HlaeObsTools/ViewModels/Docks/Viewport3DDockViewModel.cs
@@ -15,6 +15,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using HlaeObsTools.Controls;
 
 namespace HlaeObsTools.ViewModels.Docks;
 
@@ -78,6 +79,7 @@ public sealed class Viewport3DDockViewModel : Tool, IDisposable
     }
 
     public Viewport3DSettings Viewport3DSettings => _settings;
+    public IViewport3DControl? Viewport { get; set; }
     public FreecamSettings FreecamSettings => _freecamSettings;
     public HlaeInputSender? InputSender => _inputSender;
     public CampathEditorViewModel CampathEditor { get; }

--- a/HlaeObsTools/ViewModels/MainDockFactory.cs
+++ b/HlaeObsTools/ViewModels/MainDockFactory.cs
@@ -184,7 +184,6 @@ public class MainDockFactory : Factory, IDisposable
 
         // Create the docks (top-right hosts the CS2 console)
         var bottomRight = new CampathsDockViewModel { Id = "BottomRight", Title = "Campaths" };
-        var topLeft = new RadarDockViewModel(_gsiServer, _radarConfigProvider, radarSettings, bottomRight, _webSocketClient) { Id = "TopLeft", Title = "Radar" };
         _videoDisplayVm = new VideoDisplayDockViewModel { Id = "TopCenter", Title = "Video Stream" };
         var topRight = new NetConsoleDockViewModel { Id = "TopRight", Title = "Console" };
         var bottomLeft = new SettingsDockViewModel(
@@ -201,6 +200,8 @@ public class MainDockFactory : Factory, IDisposable
             campathEditor: campathEditor)
         { Id = "BottomLeft", Title = "Settings" };
         var bottomCenter = new Viewport3DDockViewModel(viewport3DSettings, freecamSettings, campathEditor, _webSocketClient, _videoDisplayVm, _gsiServer) { Id = "BottomCenter", Title = "3D Viewport" };
+        var topLeft = new RadarDockViewModel(_gsiServer, _radarConfigProvider, radarSettings, bottomRight, _webSocketClient, bottomCenter) { Id = "TopLeft", Title = "Radar" };
+
         bottomCenter.SetInputSender(_inputSender);
 
         // Inject WebSocket and UDP services into video display

--- a/HlaeObsTools/Views/Docks/RadarDockView.axaml
+++ b/HlaeObsTools/Views/Docks/RadarDockView.axaml
@@ -118,10 +118,12 @@
             </ItemsControl.ItemTemplate>
           </ItemsControl>
 
+			<!-- Alive player markers -->
           <ItemsControl ItemsSource="{Binding Players}"
                         Width="1024"
                         Height="1024"
-                        IsHitTestVisible="False"
+                        IsHitTestVisible="True"
+						Cursor="Hand"
                         x:CompileBindings="False">
             <ItemsControl.Styles>
               <Style Selector="ContentPresenter">
@@ -138,7 +140,8 @@
               <DataTemplate x:DataType="vm:RadarPlayerViewModel">
                 <Canvas Width="36"
                         Height="36"
-                        RenderTransformOrigin="0.5,0.5">
+                        RenderTransformOrigin="0.5,0.5"
+						PointerPressed="RadarPlayer_PointerPressed">
                   <Canvas.RenderTransform>
                     <ScaleTransform ScaleX="{Binding MarkerScale}"
                                     ScaleY="{Binding MarkerScale}" />

--- a/HlaeObsTools/Views/Docks/RadarDockView.axaml.cs
+++ b/HlaeObsTools/Views/Docks/RadarDockView.axaml.cs
@@ -36,4 +36,13 @@ public partial class RadarDockView : UserControl
             vm.SetCampathHighlight(path, false);
         }
     }
+    private void RadarPlayer_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is RadarDockViewModel vm && sender is Control ctrl && ctrl.DataContext is RadarPlayerViewModel player)
+        {
+            // Not implemented yet
+            // Console.WriteLine($"Player {player.DisplayNumber} pressed (ID: {player.Id})");
+            e.Handled = true;
+        }
+    }
 }

--- a/HlaeObsTools/Views/Docks/RadarDockView.axaml.cs
+++ b/HlaeObsTools/Views/Docks/RadarDockView.axaml.cs
@@ -1,7 +1,10 @@
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 using Avalonia.Input;
+using Avalonia.LogicalTree;
+using Avalonia.Markup.Xaml;
+using HlaeObsTools.Services.WebSocket;
 using HlaeObsTools.ViewModels.Docks;
+using System.Security.Cryptography;
 
 namespace HlaeObsTools.Views.Docks;
 
@@ -40,8 +43,11 @@ public partial class RadarDockView : UserControl
     {
         if (DataContext is RadarDockViewModel vm && sender is Control ctrl && ctrl.DataContext is RadarPlayerViewModel player)
         {
-            // Not implemented yet
-            // Console.WriteLine($"Player {player.DisplayNumber} pressed (ID: {player.Id})");
+            if(e.Properties.IsLeftButtonPressed)
+                vm.SwitchToPlayer(player);
+            else if(e.Properties.IsMiddleButtonPressed)
+                vm.TeleportViewportCameraToPlayer(player);
+
             e.Handled = true;
         }
     }

--- a/HlaeObsTools/Views/Docks/Viewport3DDockView.axaml.cs
+++ b/HlaeObsTools/Views/Docks/Viewport3DDockView.axaml.cs
@@ -18,7 +18,11 @@ namespace HlaeObsTools.Views.Docks;
 public partial class Viewport3DDockView : UserControl
 {
     private Viewport3DDockViewModel? _viewModel;
-    private IViewport3DControl? _viewport;
+    private IViewport3DControl? _viewport
+    {
+        get => _viewModel?.Viewport;
+        set => _viewModel?.Viewport = value;
+    }
     private Control? _viewportControl;
     private IReadOnlyList<ViewportPin>? _lastPins;
     private CampathEditorViewModel? _campathEditor;


### PR DESCRIPTION
# Clickable radar players
- LMB to spectate the player (runs a spec_player command)
- MMB to teleport the 3D viewport camera to the player

⚠️ Had to move the viewport from Viewport3DDockView to Viewport3DDockViewModel so that other objects could access it. LMK if this is bad practice and I should come up with another way to do this.
Tested locally.